### PR TITLE
feat: Add assert

### DIFF
--- a/src/main/java/controllers/InputParser.java
+++ b/src/main/java/controllers/InputParser.java
@@ -30,6 +30,7 @@ public class InputParser {
      * @throws InvalidCommandError If the command does not exist.
      */
     public Command parse(String cmd) throws InvalidInputError, InvalidCommandError {
+        assert cmd != null;
 
         if (isByeCommand(cmd)) {
             return new ByeCommand();

--- a/src/main/java/controllers/OutputHandler.java
+++ b/src/main/java/controllers/OutputHandler.java
@@ -16,6 +16,7 @@ public class OutputHandler {
 
     // Output method for both GUI and CLI
     public void print(String message) {
+        assert message != null;
         if (chatArea != null) {
             // If TextArea exists, append to it (GUI)
             chatArea.appendText(message + "\n");

--- a/src/main/java/controllers/commands/AddDeadlineCommand.java
+++ b/src/main/java/controllers/commands/AddDeadlineCommand.java
@@ -31,6 +31,8 @@ public class AddDeadlineCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         taskList.addTask(this.task);
         outputHandler.print("____________________________________________________________\n" +
                 "added: " + this.task.getDescription() + "\n" +

--- a/src/main/java/controllers/commands/AddEventCommand.java
+++ b/src/main/java/controllers/commands/AddEventCommand.java
@@ -31,6 +31,8 @@ public class AddEventCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         taskList.addTask(this.task);
         outputHandler.print("____________________________________________________________\n" +
                 "added: " + this.task.getDescription() + "\n" +

--- a/src/main/java/controllers/commands/AddTaskCommand.java
+++ b/src/main/java/controllers/commands/AddTaskCommand.java
@@ -31,6 +31,8 @@ public class AddTaskCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         taskList.addTask(this.task);
         outputHandler.print("____________________________________________________________\n" +
                 "added: " + this.task.getDescription() + "\n" +

--- a/src/main/java/controllers/commands/AddTodoCommand.java
+++ b/src/main/java/controllers/commands/AddTodoCommand.java
@@ -32,6 +32,8 @@ public class AddTodoCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         taskList.addTask(this.task);
         outputHandler.print("____________________________________________________________\n" +
                 "added: " + this.task.getDescription() + "\n" +

--- a/src/main/java/controllers/commands/ByeCommand.java
+++ b/src/main/java/controllers/commands/ByeCommand.java
@@ -20,6 +20,8 @@ public class ByeCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         outputHandler.print(
                 "Bye. Hope to see you again soon!\n" +
                         "____________________________________________________________");

--- a/src/main/java/controllers/commands/DeleteTaskCommand.java
+++ b/src/main/java/controllers/commands/DeleteTaskCommand.java
@@ -31,6 +31,9 @@ public class DeleteTaskCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
+
         Task task = taskList.removeTask(this.index);
         outputHandler.print("____________________________________________________________\n" +
                 "Removed: " + task.getDescription() + "\n" +

--- a/src/main/java/controllers/commands/FindCommand.java
+++ b/src/main/java/controllers/commands/FindCommand.java
@@ -33,6 +33,8 @@ public class FindCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
 
         outputHandler.print("This are some possible tasks found");
 

--- a/src/main/java/controllers/commands/ListCommand.java
+++ b/src/main/java/controllers/commands/ListCommand.java
@@ -20,6 +20,9 @@ public class ListCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         outputHandler.print(taskList.listTasks());
     }
 }

--- a/src/main/java/controllers/commands/MarkTaskCommand.java
+++ b/src/main/java/controllers/commands/MarkTaskCommand.java
@@ -32,6 +32,8 @@ public class MarkTaskCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         try {
             taskList.markTask(index - 1);
             outputHandler.print("____________________________________________________________");

--- a/src/main/java/controllers/commands/UnmarkTaskCommand.java
+++ b/src/main/java/controllers/commands/UnmarkTaskCommand.java
@@ -32,6 +32,8 @@ public class UnmarkTaskCommand implements Command {
      */
     @Override
     public void execute(TaskList taskList, OutputHandler outputHandler) {
+        assert taskList != null : "taskList must not be null";
+        assert outputHandler != null : "outputHandler must not be null";
         try {
             taskList.unmarkTask(index - 1);
             outputHandler.print("____________________________________________________________");

--- a/src/main/java/models/TaskList.java
+++ b/src/main/java/models/TaskList.java
@@ -58,6 +58,7 @@ public class TaskList extends ActiveRecord {
      * @param task The task to be added to the list.
      */
     public void addTask(Task task) {
+        assert task != null;
         tasks.add(task);
         saveToDb();
     }


### PR DESCRIPTION
Add null check assertion in parse method

The parse method does not currently check if the cmd parameter is null, which could lead to a NullPointerException during execution.

To prevent potential null pointer issues and ensure the command is never null, add an assertion to verify cmd is not null.

This assertion ensures code correctness and catches errors early during development, following defensive programming practices.